### PR TITLE
Adjust and add buffer classes

### DIFF
--- a/GameProject/Engine/AssetManagement/Mesh.cpp
+++ b/GameProject/Engine/AssetManagement/Mesh.cpp
@@ -1,11 +1,14 @@
 #include "Mesh.h"
 
-Mesh::Mesh(std::vector<Vertex>* vertices, std::vector<unsigned short>* vertexIndices, unsigned short materialIndex)
+Mesh::Mesh(std::vector<Vertex>* vertices, std::vector<unsigned int>* vertexIndices, unsigned short materialIndex)
     : vertices(vertices),
     vertexIndices(vertexIndices),
     materialIndex(materialIndex)
 {
-    createBuffers();
+    VertexBuffer VBO((void*)&vertices[0], vertices->size() * sizeof(Vertex));
+    IndexBuffer indexBuffer((void*)&vertexIndices[0], vertexIndices->size() * sizeof(unsigned short));
+
+    VAO = new VertexArray();
 }
 
 Mesh::~Mesh()
@@ -13,8 +16,6 @@ Mesh::~Mesh()
     // Delete vertices and indices
     delete vertices;
     delete vertexIndices;
-}
 
-void Mesh::createBuffers()
-{
+    delete VAO;
 }

--- a/GameProject/Engine/AssetManagement/Mesh.h
+++ b/GameProject/Engine/AssetManagement/Mesh.h
@@ -2,20 +2,23 @@
 
 #include <vector>
 #include "../Rendering/GLAbstraction/RenderingResources.h"
+#include "../Rendering/GLAbstraction/VertexArray.h"
 
 class Mesh
 {
 public:
-    Mesh(std::vector<Vertex>* vertices, std::vector<unsigned short>* vertexIndices, unsigned short materialIndex);
+    Mesh(std::vector<Vertex>* vertices, std::vector<unsigned int>* vertexIndices, unsigned short materialIndex);
     ~Mesh();
 
-private:
-    void createBuffers();
+    void bindVertexBuffer();
+    void bindTextures();
+    void bindMaterial();
 
-    GLuint vertexVBO, indexVBO;
+private:
+    VertexArray* VAO;
 
     std::vector<Vertex>* vertices;
-    std::vector<unsigned short>* vertexIndices;
-    // The index refers to the material storage in the meshe's model
+    std::vector<unsigned int>* vertexIndices;
+    // The index refers to the material storage in the mesh's model
     unsigned short materialIndex;
 };

--- a/GameProject/Engine/AssetManagement/ModelLoader.cpp
+++ b/GameProject/Engine/AssetManagement/ModelLoader.cpp
@@ -112,7 +112,7 @@ void ModelLoader::processMesh(aiMesh* assimpMesh, Model* model)
 {
     // Data for the mesh
     std::vector<Vertex>* vertices = new std::vector<Vertex>;
-    std::vector<unsigned short>* indices = new std::vector<unsigned short>;
+    std::vector<unsigned int>* indices = new std::vector<unsigned int>;
 
     // Process vertices
     for (unsigned int i = 0; i < assimpMesh->mNumVertices; i += 1) {

--- a/GameProject/Engine/Rendering/GLAbstraction/Framebuffer.cpp
+++ b/GameProject/Engine/Rendering/GLAbstraction/Framebuffer.cpp
@@ -9,8 +9,6 @@ Framebuffer::Framebuffer()
 	glGenFramebuffers(1, &this->id);
 	glBindFramebuffer(GL_FRAMEBUFFER, this->id);
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-
 }
 
 Framebuffer::~Framebuffer()

--- a/GameProject/Engine/Rendering/GLAbstraction/Framebuffer.h
+++ b/GameProject/Engine/Rendering/GLAbstraction/Framebuffer.h
@@ -15,9 +15,7 @@ public:
 	void bind() const;
 	void unbind() const;
 
-
 private:
 	unsigned id;
-	
-};
 
+};

--- a/GameProject/Engine/Rendering/GLAbstraction/IndexBuffer.cpp
+++ b/GameProject/Engine/Rendering/GLAbstraction/IndexBuffer.cpp
@@ -1,0 +1,18 @@
+#include "IndexBuffer.h"
+
+IndexBuffer::IndexBuffer(const void* const data, const size_t& dataSize)
+    :dataSize(dataSize)
+{
+    glGenBuffers(1, &this->id);
+
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->id);
+
+	glBufferData(GL_ELEMENT_ARRAY_BUFFER, this->dataSize, data, GL_STATIC_DRAW);
+
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}
+
+IndexBuffer::~IndexBuffer()
+{
+    glDeleteBuffers(1, &this->id);
+}

--- a/GameProject/Engine/Rendering/GLAbstraction/IndexBuffer.h
+++ b/GameProject/Engine/Rendering/GLAbstraction/IndexBuffer.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <GL/glew.h>
+
+class IndexBuffer
+{
+public:
+    IndexBuffer(const void* const data, const size_t& dataSize);
+    ~IndexBuffer();
+
+private:
+    GLuint id;
+    size_t dataSize;
+};

--- a/GameProject/Engine/Rendering/GLAbstraction/VertexArray.cpp
+++ b/GameProject/Engine/Rendering/GLAbstraction/VertexArray.cpp
@@ -8,6 +8,13 @@ VertexArray::VertexArray()
 
 VertexArray::~VertexArray()
 {
+	// Delete VBOs
+	for (unsigned int i = 0; i < vbos.size(); i += 1) {
+		delete vbos.at(i);
+	}
+
+	delete indexBuffer;
+
 	glDeleteVertexArrays(1, &this->id);
 }
 
@@ -29,6 +36,11 @@ void VertexArray::addBuffer(VertexBuffer * vbo, const AttributeLayout& attribute
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 	vbo->setAttribCount(attributes.attribs.size());
+}
+
+void VertexArray::setIndexBuffer(IndexBuffer* indexBuffer)
+{
+	this->indexBuffer = indexBuffer;
 }
 
 void VertexArray::bind()

--- a/GameProject/Engine/Rendering/GLAbstraction/VertexArray.h
+++ b/GameProject/Engine/Rendering/GLAbstraction/VertexArray.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "VertexBuffer.h"
+#include "IndexBuffer.h"
 
 class VertexArray
 {
@@ -15,6 +16,7 @@ public:
 		Important to push attributes to attributeHandler in order of how they lay in the vertex buffer
 	*/
 	void addBuffer(VertexBuffer* vbo, const AttributeLayout& layout);
+	void setIndexBuffer(IndexBuffer* indexBuffer);
 
 	/*
 		used before drawing
@@ -26,5 +28,5 @@ private:
 	unsigned id;
 
 	std::vector<VertexBuffer*> vbos;
-
+	IndexBuffer* indexBuffer;
 };

--- a/GameProject/Engine/Rendering/GLAbstraction/VertexBuffer.cpp
+++ b/GameProject/Engine/Rendering/GLAbstraction/VertexBuffer.cpp
@@ -1,13 +1,13 @@
 #include "VertexBuffer.h"
 
-VertexBuffer::VertexBuffer(const std::vector<float>& data)
+VertexBuffer::VertexBuffer(const void* const data, const size_t& dataSize)
+	:dataSize(dataSize)
 {
-	this->data = data;
 	glGenBuffers(1, &this->id);
 
 	glBindBuffer(GL_ARRAY_BUFFER, this->id);
 
-	glBufferData(GL_ARRAY_BUFFER, sizeof(float) * this->data.size(), &this->data[0], GL_STATIC_DRAW);
+	glBufferData(GL_ARRAY_BUFFER, dataSize, data, GL_STATIC_DRAW);
 
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }

--- a/GameProject/Engine/Rendering/GLAbstraction/VertexBuffer.h
+++ b/GameProject/Engine/Rendering/GLAbstraction/VertexBuffer.h
@@ -12,7 +12,7 @@ public:
 	/*
 		Set up for vbo object data is templated
 	*/
-	VertexBuffer(const std::vector<float>& data);
+	VertexBuffer(const void* const data, const size_t& dataSize);
 	~VertexBuffer();
 
 	unsigned getID() { return this->id; };
@@ -25,11 +25,9 @@ public:
 
 private:
 	unsigned id, attribCount;
+	size_t dataSize;
 	/*
 		Locations for all attributes included in the vbo
 	*/
 	unsigned locations[5];
-
-	std::vector<float> data;
 };
-

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="Engine\InputHandler.cpp" />
     <ClCompile Include="Engine\Components\Component.cpp" />
     <ClCompile Include="Engine\Rendering\Display.cpp" />
+    <ClCompile Include="Engine\Rendering\GLAbstraction\IndexBuffer.cpp" />
     <ClCompile Include="Engine\Rendering\GLAbstraction\VertexArray.cpp" />
     <ClCompile Include="Engine\Rendering\GLAbstraction\VertexBuffer.cpp" />
     <ClCompile Include="Engine\Rendering\GLAbstraction\Framebuffer.cpp" />
@@ -51,6 +52,7 @@
     <ClInclude Include="Engine\Components\Component.h" />
     <ClInclude Include="Engine\IGame.h" />
     <ClInclude Include="Engine\Rendering\Display.h" />
+    <ClInclude Include="Engine\Rendering\GLAbstraction\IndexBuffer.h" />
     <ClInclude Include="Engine\Rendering\GLAbstraction\Shader.h" />
     <ClInclude Include="Engine\AssetManagement\Mesh.h" />
     <ClInclude Include="Engine\AssetManagement\Model.h" />


### PR DESCRIPTION
Adjusted VertexBuffer and VertexArray to take a `void*` pointer rather than `std::vector<float>`.

Added an IndexBuffer class which VertexArray is responsible for handling and storing.