### PR TITLE
Fix compiling error

### DIFF
--- a/GameProject/Tests/AssetLoading_test.cpp
+++ b/GameProject/Tests/AssetLoading_test.cpp
@@ -4,6 +4,7 @@
 #include <Catch/catch.hpp>
 
 #include "Engine/AssetManagement/ModelLoader.h"
+#include "Engine/AssetManagement/Mesh.h"
 
 TEST_CASE("ModelLoader") {
 	Model* cube = ModelLoader::loadModel("../Game/assets/cube.obj");
@@ -32,7 +33,7 @@ TEST_CASE("ModelLoader") {
 	}
 
 	SECTION("Is able to unload models from memory") {
-		ModelLoader::unloadModels();
+		ModelLoader::unloadAllModels();
 
 		CHECK(ModelLoader::modelCount() == 0);
 	}
@@ -58,7 +59,7 @@ TEST_CASE("TextureManager") {
 	}
 
 	SECTION("Is able to unload textures from memory") {
-		TextureManager::unloadTextures();
+		TextureManager::unloadAllTextures();
 		CHECK(TextureManager::textureCount() == 0);
 	}
 }

--- a/GameProject/Tests/Tests.vcxproj
+++ b/GameProject/Tests/Tests.vcxproj
@@ -129,7 +129,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\Engine\Components\Camera.h" />
+    <ClInclude Include="..\Engine\Components\FreeMove.h" />
+    <ClInclude Include="..\Engine\Rendering\GLAbstraction\IndexBuffer.h" />
+    <ClInclude Include="..\Engine\Rendering\Renderer.h" />
     <ClInclude Include="..\Game\Components\ArrowGuider.h" />
+    <ClInclude Include="..\Game\States\TestState.h" />
     <ClInclude Include="catch.hpp" />
     <ClInclude Include="..\Engine\AssetManagement\Mesh.h" />
     <ClInclude Include="..\Engine\AssetManagement\Model.h" />
@@ -166,7 +171,9 @@
     <ClCompile Include="..\Engine\AssetManagement\Model.cpp" />
     <ClCompile Include="..\Engine\AssetManagement\ModelLoader.cpp" />
     <ClCompile Include="..\Engine\AssetManagement\TextureManager.cpp" />
+    <ClCompile Include="..\Engine\Components\Camera.cpp" />
     <ClCompile Include="..\Engine\Components\Component.cpp" />
+    <ClCompile Include="..\Engine\Components\FreeMove.cpp" />
     <ClCompile Include="..\Engine\Entity\Entity.cpp" />
     <ClCompile Include="..\Engine\Entity\EntityManager.cpp" />
     <ClCompile Include="..\Engine\Entity\EntityMatrix.cpp" />
@@ -175,15 +182,18 @@
     <ClCompile Include="..\Engine\Level\Level.cpp" />
     <ClCompile Include="..\Engine\Rendering\Display.cpp" />
     <ClCompile Include="..\Engine\Rendering\GLAbstraction\Framebuffer.cpp" />
+    <ClCompile Include="..\Engine\Rendering\GLAbstraction\IndexBuffer.cpp" />
     <ClCompile Include="..\Engine\Rendering\GLAbstraction\Shader.cpp" />
     <ClCompile Include="..\Engine\Rendering\GLAbstraction\UniformBuffer.cpp" />
     <ClCompile Include="..\Engine\Rendering\GLAbstraction\VertexArray.cpp" />
     <ClCompile Include="..\Engine\Rendering\GLAbstraction\VertexBuffer.cpp" />
+    <ClCompile Include="..\Engine\Rendering\Renderer.cpp" />
     <ClCompile Include="..\Engine\States\State.cpp" />
     <ClCompile Include="..\Engine\States\StateManager.cpp" />
     <ClCompile Include="..\Game\Components\ArrowGuider.cpp" />
     <ClCompile Include="..\Game\Game.cpp" />
     <ClCompile Include="..\Game\States\MenuState.cpp" />
+    <ClCompile Include="..\Game\States\TestState.cpp" />
     <ClCompile Include="arrow_test.cpp" />
     <ClCompile Include="AssetLoading_test.cpp" />
     <ClCompile Include="Events_test.cpp" />


### PR DESCRIPTION
The Tests project wasn't compiling because some new files were added to GameProject and because of some changes being made to inclusions (Model no longer includes Mesh in the header file).