### PR TITLE
Bugfix

### DIFF
--- a/GameProject/Engine/AssetManagement/TextureManager.cpp
+++ b/GameProject/Engine/AssetManagement/TextureManager.cpp
@@ -18,6 +18,13 @@ Texture* TextureManager::loadTexture(const std::string& fileName, TextureType ty
 	// Load texture from disc and stor the data with openGL.
 	Texture* newTexture = new Texture(fileName, type);
 
+	// Check if texture was loaded.
+	if (newTexture->hasLoadedData() == false)
+	{
+		delete newTexture;
+		return nullptr;
+	}
+
     // Store the new texture in the texture map
     loadedTextures[fileName] = newTexture;
 

--- a/GameProject/Engine/AssetManagement/TextureManager.h
+++ b/GameProject/Engine/AssetManagement/TextureManager.h
@@ -13,8 +13,15 @@ class TextureManager
 {
 public:
 
-    // Loads a texture from file or finds the already loaded texture
-    static Texture* loadTexture(const std::string& fileName, TextureType type);
+	/*
+	Loads a texture from file or finds the already loaded texture.
+	Arguments:
+		fileName: The path to the file.
+		type: The type of texture. E.g Diffuse, specular etc.
+	Return:
+		nullptr if not found else a pointer to the texture.
+	*/
+    static Texture* loadTexture(const std::string& fileName, TextureType type = TextureType::TXTYPE_DIFFUSE);
 
 	/*
 	Get a stored texture.
@@ -25,7 +32,14 @@ public:
 	*/
 	static Texture* getTexture(const std::string& fileName);
 
+	/*
+	Free all loaded textures from memory.
+	*/
     static void unloadAllTextures();
+
+	/*
+	Get the number of textures loaded.
+	*/
     static size_t textureCount();
 
 private:

--- a/GameProject/Engine/Rendering/Display.h
+++ b/GameProject/Engine/Rendering/Display.h
@@ -41,6 +41,9 @@ public:
 	~Display();
 
 private:
+	Display() = default;
+	Display(const Display& other) = delete;
+
 	static void errorCallback(int error, const char* description);
 	static void resizeCallback(GLFWwindow* window, int width, int height);
 

--- a/GameProject/Engine/Rendering/GLAbstraction/Texture.cpp
+++ b/GameProject/Engine/Rendering/GLAbstraction/Texture.cpp
@@ -5,7 +5,7 @@
 
 #include "GLFormats.h"
 
-Texture::Texture() : id(0)
+Texture::Texture() : id(0), loaded(false)
 {
 }
 
@@ -114,6 +114,11 @@ GLuint Texture::getFormat() const
 	return this->format;
 }
 
+bool Texture::hasLoadedData() const
+{
+	return this->loaded;
+}
+
 void Texture::bind()
 {
 	glBindTexture(GL_TEXTURE_2D, this->id);
@@ -132,6 +137,7 @@ void Texture::copyData(const Texture & other)
 	this->height = other.getHeight();
 	this->internalFormat = other.getInternalFormat();
 	this->format = other.getFormat();
+	this->loaded = other.loaded;
 	
 	// Copy texture data
 	size_t size = this->width*this->height * Formats::getTextureFormatChannels(this->format);
@@ -162,6 +168,7 @@ void Texture::loadImage(const std::string & fileName, TextureType texType, unsig
 	if (!data)
 	{
 		LOG_WARNING("Unable to load texture [%s]", fileName.c_str());
+		this->loaded = false;
 		return;
 	}
 
@@ -171,6 +178,8 @@ void Texture::loadImage(const std::string & fileName, TextureType texType, unsig
 
 	// Free image data as OpenGL is storing a copy
 	stbi_image_free(data);
+
+	this->loaded = true;
 }
 
 void Texture::init(unsigned char * data, unsigned int width, unsigned int height, unsigned internalFormat, unsigned format, TextureType texType)
@@ -185,6 +194,8 @@ void Texture::init(unsigned char * data, unsigned int width, unsigned int height
 	bind();
 	glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, format, GL_UNSIGNED_BYTE, data);
 	setParameters();
+
+	this->loaded = true;
 }
 
 void Texture::setParameters()

--- a/GameProject/Engine/Rendering/GLAbstraction/Texture.h
+++ b/GameProject/Engine/Rendering/GLAbstraction/Texture.h
@@ -123,6 +123,11 @@ public:
 	Get the format of the data which was passed to the texture.
 	*/
 	GLuint getFormat() const;
+	
+	/*
+	Return true if the data was loaded correctly, otherwise false.
+	*/
+	bool hasLoadedData() const;
 
 	void bind();
 	void unbind();
@@ -142,4 +147,6 @@ private:
 
 	unsigned int width;
 	unsigned int height;
+
+	bool loaded;
 };

--- a/GameProject/Utils/Logger.cpp
+++ b/GameProject/Utils/Logger.cpp
@@ -21,11 +21,6 @@ void Logger::init()
 	file.open(PATH_TO_LOG_FILE);
 }
 
-void Logger::destroy()
-{
-	file.close();
-}
-
 void Logger::setFilter(unsigned int filterTypes)
 {
 	filter = filterTypes;
@@ -34,6 +29,11 @@ void Logger::setFilter(unsigned int filterTypes)
 void Logger::logToFile(bool toFile)
 {
 	writeToFile = toFile;
+}
+
+Logger::~Logger()
+{
+	file.close();
 }
 
 bool Logger::shouldPrint(TYPE type)

--- a/GameProject/Utils/Logger.h
+++ b/GameProject/Utils/Logger.h
@@ -40,11 +40,6 @@ public:
 	Initialize the logger.
 	*/
 	static void init();
-	
-	/*
-	Clean up the logger.
-	*/
-	static void destroy();
 
 	/*
 	Print a formatted white string with [INFO] as a prefix.
@@ -111,6 +106,8 @@ public:
 		TYPE_ERROR = 4,
 		TYPE_SUCCESS = 8
 	};
+
+	~Logger();
 
 private:
 	enum CONSOLE_COLOR

--- a/GameProject/main.cpp
+++ b/GameProject/main.cpp
@@ -27,8 +27,6 @@ int main() {
 
 	Game game;
 	game.start();
-	
-	Logger::destroy();
 
 	ModelLoader::unloadAllModels();
 	TextureManager::unloadAllTextures();


### PR DESCRIPTION
Fixed Bugs:
* The function loadTexture in TextureManager now return a nullptr if the texture was not found.
* When logging in a state's destructor it will now log to the file too.

Fixes:
* Added a default private constructor to Display and deleted the copy constructor.