### PR TITLE
Added mouseScrollEvent

### DIFF
--- a/GameProject/Engine/Events/Events.h
+++ b/GameProject/Engine/Events/Events.h
@@ -49,6 +49,13 @@ struct MouseClickEvent : public Event
 	int action;
 };
 
+struct MouseScrollEvent : public Event
+{
+	MouseScrollEvent(int xoffset, int yoffset) : xoffset{ xoffset }, yoffset{ yoffset } {};
+	int xoffset;
+	int yoffset;
+};
+
 struct PlayerCollisionEvent : public Event
 {
 	PlayerCollisionEvent(Entity* entity1, Entity* entity2, const reactphysics3d::ProxyShape * shape1, const reactphysics3d::ProxyShape * shape2) : entity1{ entity1 }, entity2{ entity2 }, shape1{ shape1 }, shape2{ shape2 } {};

--- a/GameProject/Engine/InputHandler.cpp
+++ b/GameProject/Engine/InputHandler.cpp
@@ -34,11 +34,17 @@ void InputHandler::mouseClickCallback(GLFWwindow * window, int button, int actio
 	EventBus::get().publish(&MouseClickEvent(button, action));
 }
 
+void InputHandler::mouseScrollCallback(GLFWwindow * window, double xoffset, double yoffset)
+{
+	EventBus::get().publish(&MouseScrollEvent((int)xoffset, (int)yoffset));
+}
+
 InputHandler::InputHandler(GLFWwindow* window)
 {
 	glfwSetKeyCallback(window, this->keyCallback);
 	glfwSetCursorPosCallback(window, this->mouseMoveCallback);
 	glfwSetMouseButtonCallback(window, this->mouseClickCallback);
+	glfwSetScrollCallback(window, this->mouseScrollCallback);
 }
 
 

--- a/GameProject/Engine/InputHandler.h
+++ b/GameProject/Engine/InputHandler.h
@@ -13,6 +13,7 @@ private:
 	static void keyCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
 	static void mouseMoveCallback(GLFWwindow* window, double xpos, double ypos);
 	static void mouseClickCallback(GLFWwindow* window, int button, int action, int mods);
+	static void mouseScrollCallback(GLFWwindow* window, double xoffset, double yoffset);
 public:
 	InputHandler(GLFWwindow* window);
 	virtual ~InputHandler();


### PR DESCRIPTION
- InputHandler now supports the use of the mouse scroll using the GLFW callback function.

If you use this, please check beforehand what the event gives you when the scroll is being used, as it may not give what you might expect (left on scroll seems to be positive for instance).