### PR TITLE
Track flighttime in guidingphase

### DIFF
--- a/GameProject/Engine/Events/EventBus.h
+++ b/GameProject/Engine/Events/EventBus.h
@@ -43,7 +43,7 @@ public:
 private:
 	template<class T, class EventType>
 	static unsigned getID(T* instance);
-	
+
 	std::map<std::type_index, HandlerList*> subscribers;
 };
 

--- a/GameProject/Game/Components/ArrowGuider.cpp
+++ b/GameProject/Game/Components/ArrowGuider.cpp
@@ -176,16 +176,18 @@ void ArrowGuider::startGuiding()
     path.push_back(startingKeyPoint);    
 }
 
-void ArrowGuider::stopGuiding()
+void ArrowGuider::stopGuiding(float flightTime)
 {
     isGuiding = false;
 
     stopAiming();
 
+    this->flightTime = flightTime;
+
     // Store end point
     KeyPoint newKeyPoint;
     newKeyPoint.Position = host->getTransform()->getPosition();
-    newKeyPoint.t = flightTime;
+    newKeyPoint.t = this->flightTime;
 
     path.push_back(newKeyPoint);
 }

--- a/GameProject/Game/Components/ArrowGuider.h
+++ b/GameProject/Game/Components/ArrowGuider.h
@@ -28,7 +28,7 @@ public:
     // Enables both aim and movement
     void startGuiding();
     // Disables both aim and movement
-    void stopGuiding();
+    void stopGuiding(float flightTime);
 
     // Event handlers
     void handleMouseMove(MouseMoveEvent* event);

--- a/GameProject/Game/GameLogic/GuidingPhase.cpp
+++ b/GameProject/Game/GameLogic/GuidingPhase.cpp
@@ -50,7 +50,11 @@ void GuidingPhase::handleKeyInput(KeyEvent* event)
     if (event->key == GLFW_KEY_3) {
         EventBus::get().unsubscribe(this, &GuidingPhase::handleKeyInput);
 
-        arrowGuider->stopGuiding();
+		// Get flight time
+		flightTimer.stop();
+		float flightTime = flightTimer.getDeltaTime();
+
+        arrowGuider->stopGuiding(flightTime);
 
         // Begin camera transition to the replay freecam
         glm::vec3 newPos = level.player.replayCamera.position;

--- a/GameProject/Game/GameLogic/GuidingPhase.h
+++ b/GameProject/Game/GameLogic/GuidingPhase.h
@@ -2,6 +2,7 @@
 
 #include <Game/GameLogic/Phase.h>
 #include <Game/Components/ArrowGuider.h>
+#include <Utils/Timer.h>
 
 // Phases GuidingPhase can transition from
 class AimPhase;
@@ -22,4 +23,6 @@ private:
 
     Entity* playerArrow;
     ArrowGuider* arrowGuider;
+
+    Timer flightTimer;
 };


### PR DESCRIPTION
`ArrowGuider` used to only receive time updates in `update(dt)`. It did not receive any time data in `stopGuiding()` which meant it could not store the correct time in the final `KeyPoint`.

This lead to the arrow moving erratically towards the last `KeyPoint` as keypoint N and N-1 had the same timestamp.

This pull request adds a timer in `GuidingPhase` which is used to send time data when telling the `ArrowGuider` to stop guiding so that the final `KeyPoint` has a correct timestamp.