### PR TITLE
Collision component optimization

### DIFF
--- a/GameProject/Engine/Collision/CollisionHandler.cpp
+++ b/GameProject/Engine/Collision/CollisionHandler.cpp
@@ -115,6 +115,7 @@ rp3d::Quaternion shapeRot = rp3d::Quaternion::identity();
 	for (auto data : this->shapes[(size_t)shape]) {
 		rp3d::ProxyShape* proxyShape = entityBody->addCollisionShape(data->shape, rp3d::Transform(this->toReactVec(data->pos), shapeRot));
 		proxyShape->setUserData((void*)data);
+		proxyShape->setCollisionCategoryBits(data->category);
 		this->proxyShapes.push_back(proxyShape);
 	}
 
@@ -221,14 +222,14 @@ void CollisionHandler::createShapes()
 	
 #ifdef ENABLE_COLLISION_BOXES
 	//// DRONE = 0
-	this->addShape(SHAPE::DRONE, { 0.25f, 0.25f, 0.25f }, { 0.15f, 0.5f, 0.15f });
-	this->addShape(SHAPE::DRONE, { 0.05f, 0.05f, 0.05f }, { 0.75f, 0.15f, 0.15f }, { 0.0f, 0.05f, -0.25f });
+	this->addShape(SHAPE::DRONE, CATEGORY::DRONE_BODY, { 0.25f, 0.25f, 0.25f }, { 0.15f, 0.5f, 0.15f });
+	this->addShape(SHAPE::DRONE, CATEGORY::DRONE_EYE, { 0.05f, 0.05f, 0.05f }, { 0.75f, 0.15f, 0.15f }, { 0.0f, 0.05f, -0.25f });
 
 	//// BOX = 1
-	this->addShape(SHAPE::BOX, { 0.5f, 0.5f, 0.5f });
+	this->addShape(SHAPE::BOX, CATEGORY::STATIC, { 0.5f, 0.5f, 0.5f });
 
 	//// ARROW = 2
-	this->addShape(SHAPE::ARROW, { 0.05f, 0.05f, 0.5f }, { 0.0f, 0.0f, 1.0f });
+	this->addShape(SHAPE::ARROW, CATEGORY::ARROW, { 0.05f, 0.05f, 0.5f }, { 0.0f, 0.0f, 1.0f });
 #else
 	//// DRONE = 0 ---- CHANGE TO A MESH WHEN DONE
 	this->addShape(SHAPE::DRONE, { 0.25f, 0.25f, 0.25f }); 
@@ -253,12 +254,13 @@ void CollisionHandler::toggleDrawing(KeyEvent * ev)
 }
 
 
-void CollisionHandler::addShape(SHAPE shape, const glm::vec3& scale, const glm::vec3& color, const glm::vec3& pos)
+void CollisionHandler::addShape(SHAPE shape, CATEGORY cat, const glm::vec3& scale, const glm::vec3& color, const glm::vec3& pos)
 {
 	CollisionShapeDrawingData* data = new CollisionShapeDrawingData();
 	data->color = color;
 	data->scale = scale;
 	data->pos = pos;
+	data->category = cat;
 
 	rp3d::BoxShape * boxShape = new rp3d::BoxShape(toReactVec(data->scale));
 	data->shape = boxShape;
@@ -301,11 +303,12 @@ void CollisionHandler::drawCollisionBoxes()
 #else
 
 
-void CollisionHandler::addShape(SHAPE shape, const glm::vec3& scale, const glm::vec3 & pos)
+void CollisionHandler::addShape(SHAPE shape, CATEGORY cat, const glm::vec3& scale, const glm::vec3 & pos)
 {
 	CollisionShapeDrawingData* data = new CollisionShapeDrawingData();
 	data->pos = pos;
 	data->shape = new rp3d::BoxShape(this->toReactVec(scale));
+	data->category = cat;
 
 	this->shapes[(size_t)shape].push_back(data);
 }

--- a/GameProject/Engine/Collision/CollisionHandler.h
+++ b/GameProject/Engine/Collision/CollisionHandler.h
@@ -9,40 +9,12 @@
 #include "Engine/Config.h"
 #include "Engine/Events/EventBus.h"
 
+#include "CollisionInfo.h"
+
 #ifdef ENABLE_COLLISION_BOXES
 	#include "CollisionRenderer.h"
-
-
-	struct CollisionShapeDrawingData {
-		glm::vec3 color;
-		glm::vec3 scale;
-		glm::vec3 pos;
-		unsigned short category;
-		rp3d::CollisionShape * shape;
-	};
-#else
-	struct CollisionShapeDrawingData {
-		glm::vec3 pos;
-		rp3d::CollisionShape * shape;
-	};
 #endif
 
-// Enum for the shapes for the CollisionBodies
-enum class SHAPE {
-	DRONE = 0,
-	BOX = 1,
-	ARROW = 2,
-	SIZE
-};
-
-enum CATEGORY
-{
-	NO_COLLISION = 0x0000,
-	ARROW = 0x0001,
-	STATIC = 0x0002,
-	DRONE_BODY = 0x0004,
-	DRONE_EYE = 0x0008
-};
 
 // Forward declerations
 class Entity;

--- a/GameProject/Engine/Collision/CollisionHandler.h
+++ b/GameProject/Engine/Collision/CollisionHandler.h
@@ -17,6 +17,7 @@
 		glm::vec3 color;
 		glm::vec3 scale;
 		glm::vec3 pos;
+		unsigned short category;
 		rp3d::CollisionShape * shape;
 	};
 #else
@@ -36,6 +37,7 @@ enum class SHAPE {
 
 enum CATEGORY
 {
+	NO_COLLISION = 0x0000,
 	ARROW = 0x0001,
 	STATIC = 0x0002,
 	DRONE_BODY = 0x0004,
@@ -92,7 +94,7 @@ private:
 	std::vector<glm::mat4> matrices;
 	std::vector<glm::vec3> colors;
 
-	void addShape(SHAPE shape, const glm::vec3& scale, const glm::vec3& color = { 0.0f, 1.0f, 0.0f }, const glm::vec3& pos = { 0.0, 0.0, 0.0 });
+	void addShape(SHAPE shape, CATEGORY cat, const glm::vec3& scale, const glm::vec3& color = { 0.0f, 1.0f, 0.0f }, const glm::vec3& pos = { 0.0, 0.0, 0.0 });
 	std::vector<std::vector<CollisionShapeDrawingData*>> shapes;
 	std::vector<rp3d::ProxyShape*> proxyShapes;
 
@@ -101,7 +103,7 @@ private:
 
 	CollisionRenderer cRenderer;
 #else
-	void addShape(SHAPE shape, const glm::vec3& scale, const glm::vec3& pos = { 0.0, 0.0, 0.0 });
+	void addShape(SHAPE shape, CATEGORY cat, const glm::vec3& scale, const glm::vec3& pos = { 0.0, 0.0, 0.0 });
 	std::vector<std::vector<CollisionShapeDrawingData*>> shapes;
 #endif
 

--- a/GameProject/Engine/Collision/CollisionInfo.h
+++ b/GameProject/Engine/Collision/CollisionInfo.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// Enum for the shapes for the CollisionBodies
+enum class SHAPE {
+	DRONE = 0,
+	BOX = 1,
+	ARROW = 2,
+	SIZE
+};
+
+enum CATEGORY
+{
+	NO_COLLISION = 0x0000,
+	ARROW = 0x0001,
+	STATIC = 0x0002,
+	DRONE_BODY = 0x0004,
+	DRONE_EYE = 0x0008
+};
+
+#ifdef ENABLE_COLLISION_BOXES
+
+
+struct CollisionShapeDrawingData {
+	glm::vec3 color;
+	glm::vec3 scale;
+	glm::vec3 pos;
+	unsigned short category;
+	rp3d::CollisionShape * shape;
+};
+#else
+struct CollisionShapeDrawingData {
+	glm::vec3 pos;
+	rp3d::CollisionShape * shape;
+	unsigned short category;
+};
+#endif

--- a/GameProject/Engine/Components/MovingTargetCollision.cpp
+++ b/GameProject/Engine/Components/MovingTargetCollision.cpp
@@ -3,11 +3,12 @@
 #include "../Entity/Entity.h"
 #include "Engine/Events/EventBus.h"
 #include <reactphysics3d/reactphysics3d.h>
+#include <Engine/Collision/CollisionInfo.h>
 
 
 MovingTargetCollision::MovingTargetCollision(Entity * parentEntity, const std::string & tagName) : Component(parentEntity, tagName)
 {
-	flag = true;
+	this->flag = false;
 	EventBus::get().subscribe(this, &MovingTargetCollision::collide);
 }
 
@@ -18,11 +19,26 @@ MovingTargetCollision::~MovingTargetCollision()
 
 bool MovingTargetCollision::getFlag()
 {
-	return flag;
+	return this->flag;
+}
+
+void MovingTargetCollision::resetFlag()
+{
+	this->flag = false;
 }
 
 void MovingTargetCollision::update(const float & dt)
 {
+	if (this->flag)
+	{
+		// Look for the proxy shape that contains the collision shape in parameter
+		while (shape != nullptr) {
+			shape->setCollisionCategoryBits(CATEGORY::NO_COLLISION);
+
+			// Get the next element in the list
+			shape = shape->getNext();
+		}
+	}
 }
 
 void MovingTargetCollision::collide(PlayerCollisionEvent * evnt)
@@ -30,5 +46,11 @@ void MovingTargetCollision::collide(PlayerCollisionEvent * evnt)
 	if (evnt->entity1 == host || evnt->entity2 == host)
 	{
 		this->host->getTransform()->translate({ 0.0, 2.0, 0.0 });
+
+		rp3d::CollisionBody* body = evnt->entity2->getCollisionBody();
+
+		shape = body->getProxyShapesList();
+
+		this->flag = true;
 	}
 }

--- a/GameProject/Engine/Components/MovingTargetCollision.cpp
+++ b/GameProject/Engine/Components/MovingTargetCollision.cpp
@@ -8,7 +8,7 @@
 
 MovingTargetCollision::MovingTargetCollision(Entity * parentEntity, const std::string & tagName) : Component(parentEntity, tagName)
 {
-	this->flag = false;
+	this->hit = false;
 	EventBus::get().subscribe(this, &MovingTargetCollision::collide);
 }
 
@@ -17,19 +17,19 @@ MovingTargetCollision::~MovingTargetCollision()
 	EventBus::get().unsubscribe(this, &MovingTargetCollision::collide);
 }
 
-bool MovingTargetCollision::getFlag()
+bool MovingTargetCollision::isHit()
 {
-	return this->flag;
+	return this->hit;
 }
 
-void MovingTargetCollision::resetFlag()
+void MovingTargetCollision::enableCollision()
 {
-	this->flag = false;
+	this->hit = false;
 }
 
 void MovingTargetCollision::update(const float & dt)
 {
-	if (this->flag)
+	if (this->hit)
 	{
 		// Look for the proxy shape that contains the collision shape in parameter
 		while (shape != nullptr) {
@@ -51,6 +51,6 @@ void MovingTargetCollision::collide(PlayerCollisionEvent * evnt)
 
 		shape = body->getProxyShapesList();
 
-		this->flag = true;
+		this->hit = true;
 	}
 }

--- a/GameProject/Engine/Components/MovingTargetCollision.h
+++ b/GameProject/Engine/Components/MovingTargetCollision.h
@@ -6,18 +6,24 @@
 	This class is added to all of the targets (drones and whatnot) that should react when a collision to them has happened.
 */
 
-namespace reactphysics3d { class ProxyShapes; }
+namespace reactphysics3d { class ProxyShape; }
 
 class MovingTargetCollision : public Component
 {
 public:
 	MovingTargetCollision(Entity * parentEntity, const std::string& tagName = "MovingTargetCollision");
 	virtual ~MovingTargetCollision();
+
+	// Returns the current flag status
 	bool getFlag();
+	// Reset the flag to false
+	void resetFlag();
 
 	void update(const float& dt);
 
 private:
 	bool flag;
 	void collide(PlayerCollisionEvent * evnt);
+
+	reactphysics3d::ProxyShape* shape;
 };

--- a/GameProject/Engine/Components/MovingTargetCollision.h
+++ b/GameProject/Engine/Components/MovingTargetCollision.h
@@ -15,14 +15,14 @@ public:
 	virtual ~MovingTargetCollision();
 
 	// Returns the current flag status
-	bool getFlag();
+	bool isHit();
 	// Reset the flag to false
-	void resetFlag();
+	void enableCollision();
 
 	void update(const float& dt);
 
 private:
-	bool flag;
+	bool hit;
 	void collide(PlayerCollisionEvent * evnt);
 
 	reactphysics3d::ProxyShape* shape;

--- a/GameProject/Engine/Components/PlayerCollision.cpp
+++ b/GameProject/Engine/Components/PlayerCollision.cpp
@@ -23,5 +23,5 @@ void PlayerCollision::update(const float & dt)
 
 void PlayerCollision::collide(PlayerCollisionEvent * evnt)
 {
-	LOG_INFO("PLAYER COLLIDED");
+	LOG_INFO("Collision: %d", evnt->shape2->getCollisionCategoryBits());
 }

--- a/GameProject/Engine/Components/StaticTargetCollision.cpp
+++ b/GameProject/Engine/Components/StaticTargetCollision.cpp
@@ -2,11 +2,12 @@
 
 #include "../Entity/Entity.h"
 #include <reactphysics3d/reactphysics3d.h>
+#include <Engine/Collision/CollisionInfo.h>
 
 
 StaticTargetCollision::StaticTargetCollision(Entity * parentEntity, const std::string & tagName) : Component(parentEntity, tagName)
 {
-	flag = true;
+	this->flag = false;
 	EventBus::get().subscribe(this, &StaticTargetCollision::collide);
 }
 
@@ -17,11 +18,26 @@ StaticTargetCollision::~StaticTargetCollision()
 
 bool StaticTargetCollision::getFlag()
 {
-	return flag;
+	return this->flag;
+}
+
+void StaticTargetCollision::resetFlag()
+{
+	this->flag = false;
 }
 
 void StaticTargetCollision::update(const float & dt)
 {
+	if (this->flag)
+	{
+		// Look for the proxy shape that contains the collision shape in parameter
+		while (shape != nullptr) {
+			shape->setCollisionCategoryBits(CATEGORY::NO_COLLISION);
+
+			// Get the next element in the list
+			shape = shape->getNext();
+		}
+	}
 }
 
 void StaticTargetCollision::collide(PlayerCollisionEvent * evnt)
@@ -31,5 +47,10 @@ void StaticTargetCollision::collide(PlayerCollisionEvent * evnt)
 		// Change color on collision of drone entity
 		this->host->getModel()->updateInstancingSpecificData(&glm::vec3(1.0, 0.0, 0.0)[0], sizeof(glm::vec3),
 			this->host->getRenderingGroupIndex() * sizeof(glm::vec3), 0, 2);
+		
+		rp3d::CollisionBody* body = evnt->entity2->getCollisionBody();
+
+		this->shape = body->getProxyShapesList();
+		this->flag = true;
 	}
 }

--- a/GameProject/Engine/Components/StaticTargetCollision.cpp
+++ b/GameProject/Engine/Components/StaticTargetCollision.cpp
@@ -7,7 +7,7 @@
 
 StaticTargetCollision::StaticTargetCollision(Entity * parentEntity, const std::string & tagName) : Component(parentEntity, tagName)
 {
-	this->flag = false;
+	this->hit = false;
 	EventBus::get().subscribe(this, &StaticTargetCollision::collide);
 }
 
@@ -16,19 +16,19 @@ StaticTargetCollision::~StaticTargetCollision()
 	EventBus::get().unsubscribe(this, &StaticTargetCollision::collide);
 }
 
-bool StaticTargetCollision::getFlag()
+bool StaticTargetCollision::isHit()
 {
-	return this->flag;
+	return this->hit;
 }
 
-void StaticTargetCollision::resetFlag()
+void StaticTargetCollision::enableCollision()
 {
-	this->flag = false;
+	this->hit = false;
 }
 
 void StaticTargetCollision::update(const float & dt)
 {
-	if (this->flag)
+	if (this->hit)
 	{
 		// Look for the proxy shape that contains the collision shape in parameter
 		while (shape != nullptr) {
@@ -51,6 +51,6 @@ void StaticTargetCollision::collide(PlayerCollisionEvent * evnt)
 		rp3d::CollisionBody* body = evnt->entity2->getCollisionBody();
 
 		this->shape = body->getProxyShapesList();
-		this->flag = true;
+		this->hit = true;
 	}
 }

--- a/GameProject/Engine/Components/StaticTargetCollision.h
+++ b/GameProject/Engine/Components/StaticTargetCollision.h
@@ -15,14 +15,14 @@ public:
 	virtual ~StaticTargetCollision();
 
 	// Returns the current flag status
-	bool getFlag();
+	bool isHit();
 	// Reset the flag to false
-	void resetFlag();
+	void enableCollision();
 
 	void update(const float& dt);
 
 private:
-	bool flag;
+	bool hit;
 	void collide(PlayerCollisionEvent * evnt);
 
 	reactphysics3d::ProxyShape* shape;

--- a/GameProject/Engine/Components/StaticTargetCollision.h
+++ b/GameProject/Engine/Components/StaticTargetCollision.h
@@ -6,18 +6,24 @@
 	This class is added to all of the targets (drones and whatnot) that should react when a collision to them has happened.
 */
 
-namespace reactphysics3d { class ProxyShapes; }
+namespace reactphysics3d { class ProxyShape; }
 
 class StaticTargetCollision : public Component
 {
 public:
 	StaticTargetCollision(Entity * parentEntity, const std::string& tagName = "StaticTargetCollision");
 	virtual ~StaticTargetCollision();
+
+	// Returns the current flag status
 	bool getFlag();
+	// Reset the flag to false
+	void resetFlag();
 
 	void update(const float& dt);
 
 private:
 	bool flag;
 	void collide(PlayerCollisionEvent * evnt);
+
+	reactphysics3d::ProxyShape* shape;
 };

--- a/GameProject/Game/GameLogic/TargetManager.cpp
+++ b/GameProject/Game/GameLogic/TargetManager.cpp
@@ -19,6 +19,9 @@ TargetManager::~TargetManager()
 
 void TargetManager::addStaticTarget(Entity* host, const glm::vec3& position)
 {
+	// Reset collision
+	resetStaticCollision();
+
     // Set position and forward
     Transform* transform = host->getTransform();
 
@@ -40,6 +43,9 @@ void TargetManager::addStaticTarget(Entity* host, const glm::vec3& position)
 
 void TargetManager::addMovingTarget(Entity* host, const std::vector<KeyPoint>& path)
 {
+	// Reset collision
+	resetMovingCollision();
+
     // Set position and forward
     Transform* transform = host->getTransform();
 
@@ -63,11 +69,9 @@ void TargetManager::resetTargets()
 {
 	// Moving targets
     resetMovingTargets();
-	resetMovingCollision();
 
 	// Static targets
     resetStaticTargets();
-	resetStaticCollision();
 }
 
 void TargetManager::setupTargetGeneric(Entity* host)

--- a/GameProject/Game/GameLogic/TargetManager.cpp
+++ b/GameProject/Game/GameLogic/TargetManager.cpp
@@ -19,9 +19,6 @@ TargetManager::~TargetManager()
 
 void TargetManager::addStaticTarget(Entity* host, const glm::vec3& position)
 {
-	// Reset collision
-	resetStaticCollision();
-
     // Set position and forward
     Transform* transform = host->getTransform();
 
@@ -43,9 +40,6 @@ void TargetManager::addStaticTarget(Entity* host, const glm::vec3& position)
 
 void TargetManager::addMovingTarget(Entity* host, const std::vector<KeyPoint>& path)
 {
-	// Reset collision
-	resetMovingCollision();
-
     // Set position and forward
     Transform* transform = host->getTransform();
 
@@ -81,6 +75,9 @@ void TargetManager::setupTargetGeneric(Entity* host)
 
 void TargetManager::resetStaticTargets()
 {
+	// Reset collision
+	resetStaticCollision();
+
 	unsigned int staticTargetCount = staticTargets.size();
 
     for (unsigned int i = 0; i != staticTargetCount; i += 1) {
@@ -94,6 +91,9 @@ void TargetManager::resetStaticTargets()
 
 void TargetManager::resetMovingTargets()
 {
+	// Reset collision
+	resetMovingCollision();
+
 	unsigned int movingTargetCount = movingTargets.size();
 
     for (unsigned int i = 0; i != movingTargetCount; i += 1) {
@@ -113,7 +113,7 @@ void TargetManager::resetStaticCollision()
 		rp3d::ProxyShape* current = body->getProxyShapesList();
 
 		StaticTargetCollision* comp = dynamic_cast<StaticTargetCollision*>(host->getComponent("StaticTargetCollision"));
-		comp->resetFlag();
+		comp->enableCollision();
 
 		// Look for the proxy shape that contains the collision shape in parameter
 		while (current != nullptr) {
@@ -137,7 +137,7 @@ void TargetManager::resetMovingCollision()
 		rp3d::ProxyShape* current = body->getProxyShapesList();
 
 		MovingTargetCollision* comp = dynamic_cast<MovingTargetCollision*>(host->getComponent("MovingTargetCollision"));
-		comp->resetFlag();
+		comp->enableCollision();
 
 		// Look for the proxy shape that contains the collision shape in parameter
 		while (current != nullptr) {

--- a/GameProject/Game/GameLogic/TargetManager.h
+++ b/GameProject/Game/GameLogic/TargetManager.h
@@ -38,6 +38,9 @@ private:
     void resetStaticTargets();
     void resetMovingTargets();
 
+	void resetStaticCollision();
+	void resetMovingCollision();
+
     std::vector<MovingTarget> movingTargets;
     std::vector<StaticTarget> staticTargets;
 };

--- a/GameProject/GameProject.vcxproj
+++ b/GameProject/GameProject.vcxproj
@@ -92,6 +92,7 @@
     <ClCompile Include="Utils\Timer.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Engine\Collision\CollisionInfo.h" />
     <ClInclude Include="Engine\Rendering\Shaders\ShaderShells\DroneShader.h" />
     <ClInclude Include="Engine\Collision\CollisionRenderer.h" />
     <ClInclude Include="Engine\Collision\Collision.h" />


### PR DESCRIPTION
- Collision components now only listen to one collide callback, when that callback has been done it will no longer listen to it until reset.
- Target manager now has a reset collision for the different collision components.