### PR TITLE
Fix twitching when starting cam transition

### DIFF
--- a/GameProject/Engine/Components/Camera.cpp
+++ b/GameProject/Engine/Components/Camera.cpp
@@ -47,6 +47,13 @@ glm::vec3 Camera::getForward() const
 	return this->f;
 }
 
+void Camera::setForward(const glm::vec3 & forward)
+{
+	this->f = glm::normalize(forward);
+	this->r = glm::cross(this->f, GLOBAL_UP_VECTOR);
+	this->u = glm::cross(this->r, this->f);
+}
+
 glm::vec3 Camera::getRight() const
 {
 	return this->r;
@@ -70,6 +77,13 @@ glm::mat4 Camera::getProj() const
 glm::vec3 Camera::getPosition() const
 {
 	return this->pos;
+}
+
+void Camera::setPosition(const glm::vec3& position)
+{
+	this->pos = position;
+
+	updateView();
 }
 
 float Camera::getFOV() const
@@ -106,12 +120,6 @@ void Camera::updateProj(WindowResizeEvent * evnt)
 	this->proj = glm::perspective(glm::radians(this->fov), Display::get().getRatio(), this->zNear, this->zFar);
 }
 
-void Camera::setForward(const glm::vec3 & forward)
-{
-	this->f = glm::normalize(forward);
-	this->r = glm::cross(this->f, GLOBAL_UP_VECTOR);
-	this->u = glm::cross(this->r, this->f);
-}
 
 void Camera::updatePosition()
 {

--- a/GameProject/Engine/Components/Camera.h
+++ b/GameProject/Engine/Components/Camera.h
@@ -21,6 +21,7 @@ public:
 	glm::vec3 getUp() const;
 	// Returns the cameras forward-vector
 	glm::vec3 getForward() const;
+	void setForward(const glm::vec3 & forward);
 	// Returns the cameras right-vector
 	glm::vec3 getRight() const;
 
@@ -32,6 +33,7 @@ public:
 	glm::mat4 getProj() const;
 	// Returns the position of the camera in world. This is its parent pos with the added offset.
 	glm::vec3 getPosition() const;
+	void setPosition(const glm::vec3& position);
 
 	float getFOV() const;
 	void setFOV(const float FOV);
@@ -48,7 +50,6 @@ private:
 	void updateProj(WindowResizeEvent * evnt);
 
 	// Set the forward-vector and in the process the right and up vector aswell
-	void setForward(const glm::vec3 & forward);
 	// Update camera's position relative to the parent entity
 	void updatePosition();
 };

--- a/GameProject/Game/GameLogic/Phase.cpp
+++ b/GameProject/Game/GameLogic/Phase.cpp
@@ -49,6 +49,8 @@ void Phase::setupTransition(const CameraSetting& currentCamSettings, const Camer
     transitionEntity->getTransform()->setPosition(currentPos);
     transitionEntity->getTransform()->setForward(currentCamSettings.direction);
 
+    transitionCam->setPosition(currentPos);
+    transitionCam->setForward(currentCamSettings.direction);
     transitionCam->setFOV(currentCamSettings.FOV);
     transitionCam->setOffset(glm::vec3(0.0f, 0.0f, 0.0f));
 


### PR DESCRIPTION
When starting transitions the camera component wasn't immediately updated, it was first repositioned and aligned during the next frame's update. This meant that for one frame, the camera was wrongly positioned and aligned, resulting what looked like a quick camera twitch.