### PR TITLE
Fix oversight controller bumping

### DIFF
--- a/GameProject/Game/Components/OversightController.cpp
+++ b/GameProject/Game/Components/OversightController.cpp
@@ -7,8 +7,8 @@
 OversightController::OversightController(Entity* host)
     :Component(host, "OverviewCamera")
 {
-    prevMousePosX = 0.0f;
-    mouseMoveX = 0.0f;
+    prevMousePosX = 0;
+    mouseMoveX = 0;
 
     mouseSensitivity = Settings::get().getMouseSensitivity();
 
@@ -22,7 +22,7 @@ OversightController::OversightController(Entity* host)
     double cursorPos;
     glfwGetCursorPos(Display::get().getWindowPtr(), &cursorPos, nullptr);
 
-    this->prevMousePosX = (float)cursorPos;
+    this->prevMousePosX = (int)cursorPos;
 
     EventBus::get().subscribe(this, &OversightController::handleMouseMove);
     EventBus::get().subscribe(this, &OversightController::handleKeyInput);
@@ -86,9 +86,9 @@ void OversightController::update(const float& dt)
 
 void OversightController::handleMouseMove(MouseMoveEvent* event)
 {
-    mouseMoveX += (float)event->posX - prevMousePosX;
+    mouseMoveX += event->posX - prevMousePosX;
 
-    prevMousePosX = (float)event->posX;
+    prevMousePosX = event->posX;
 
     // Divide by window height to separate turn speed from screen resolution
     rotateFactor += mouseSensitivity * mouseMoveX / windowHeight;
@@ -129,5 +129,5 @@ void OversightController::applyRotation(const float& dt)
 
     transform->rotate(rotationAngle, 0.0f);
 
-    mouseMoveX = 0.0f;
+    mouseMoveX = 0;
 }

--- a/GameProject/Game/Components/OversightController.h
+++ b/GameProject/Game/Components/OversightController.h
@@ -35,7 +35,8 @@ private:
     int windowHeight;
 
     // Refreshed each update call
-    float prevMousePosX, mouseMoveX;
+    unsigned int prevMousePosX;
+    int mouseMoveX;
 
     // Distance to the focus point
     const float rotationDistance = 6.0f;


### PR DESCRIPTION
At certain times the oversight controller would start going in the opposite direction. The issue was that the cursor position was handled by float variables when integers should have been used.