### PR TITLE
Collision fix

### DIFF
--- a/GameProject/Engine/Collision/Collision.cpp
+++ b/GameProject/Engine/Collision/Collision.cpp
@@ -2,6 +2,8 @@
 
 #include "Engine/Events/EventBus.h"
 #include "Engine/Entity/Entity.h"
+#include "Engine/Components/MovingTargetCollision.h"
+#include "Engine/Components/StaticTargetCollision.h"
 
 Collision::Collision()
 {
@@ -14,15 +16,45 @@ Collision::~Collision()
 
 void Collision::notifyContact(const CollisionCallbackInfo & info)
 {
+	// Get correspondening entity to body
 	Entity* entity1 = (*this->entites)[info.body1];
 	Entity* entity2 = (*this->entites)[info.body2];
-	const rp3d::ProxyShape * shape1 = info.proxyShape1;
-	const rp3d::ProxyShape * shape2 = info.proxyShape2;
+	
+	if (!checkIfHit(entity2))
+	{
+		const rp3d::ProxyShape * shape1 = info.proxyShape1;
+		const rp3d::ProxyShape * shape2 = info.proxyShape2;
 
-	EventBus::get().publish(&PlayerCollisionEvent(entity1, entity2, shape1, shape2));
+		EventBus::get().publish(&PlayerCollisionEvent(entity1, entity2, shape1, shape2));
+	}
 }
 
 void Collision::setEntitesPointer(std::unordered_map<rp3d::CollisionBody*, Entity*>* entites)
 {
 	this->entites = entites;
+}
+
+bool Collision::checkIfHit(Entity * e)
+{
+	// Get component of hit entity to only send an event if not already hit
+	Component* cMov = e->getComponent("MovingTargetCollision");
+	Component* cSta = e->getComponent("StaticTargetCollision");
+
+	// Dyanamic cast in if for performance reasons
+	if (cMov)
+	{
+		MovingTargetCollision* mov = dynamic_cast<MovingTargetCollision*>(cMov);
+		if (mov->isHit())
+			return true;
+		return false;
+	}
+	else if (cSta)
+	{
+		StaticTargetCollision* sta = dynamic_cast<StaticTargetCollision*>(cSta);
+		if (sta->isHit())
+			return true;
+		return false;
+	}
+	// If entity doesn't have either Moving or Static collision, it will return false, as we are not checking for that.
+	return false;
 }

--- a/GameProject/Engine/Collision/Collision.h
+++ b/GameProject/Engine/Collision/Collision.h
@@ -19,4 +19,13 @@ public:
 	void setEntitesPointer(std::unordered_map<rp3d::CollisionBody*, Entity*>* entites);
 private:
 	std::unordered_map<rp3d::CollisionBody*, Entity*>* entites;
+
+	/*
+		Check if an entity with its components has already been hit.
+		Param:
+			The entity to be checked.
+		Return:
+			True if entity is hit, false if not.
+	*/
+	bool checkIfHit(Entity* e);
 };

--- a/GameProject/Engine/Entity/Entity.h
+++ b/GameProject/Engine/Entity/Entity.h
@@ -23,7 +23,11 @@ public:
 	bool addComponent(Component* component);
 	bool removeComponent(const std::string& componentName);
 	void removeAllComponents();
-	// Used by components to get neighboring components
+	/*
+		Get component by name for the given entity
+		Returns:
+			Component pointer if found, nullptr if not.
+	*/
 	Component* getComponent(const std::string& componentName);
 
 	void setModel(Model* model);


### PR DESCRIPTION
- CollisionHandlers callback Collision now only sends out one PlayerCollisionEvent per collision, instead of the occasional two events, one for body and one for arrow.