### PR TITLE
Fix collision keypoints overwriting each other

### DIFF
--- a/GameProject/Game/Components/ArrowGuider.cpp
+++ b/GameProject/Game/Components/ArrowGuider.cpp
@@ -72,6 +72,8 @@ void ArrowGuider::update(const float& dt)
             newKeyPoint.t = flightTime;
 
             path.push_back(newKeyPoint);
+
+            allowKeypointOverride = true;
         }
 
         // Update arrow position
@@ -162,6 +164,8 @@ void ArrowGuider::startGuiding()
     isGuiding = true;
     flightTime = 0.0f;
 
+    allowKeypointOverride = true;
+
     // Clear previous path and store starting position
     path.clear();
 
@@ -191,12 +195,14 @@ void ArrowGuider::stopGuiding(float flightTime)
 void ArrowGuider::saveKeyPoint(float flightTime)
 {
     // Do not save the key point if one was just saved during the same frame update
-    if (posStoreTimer < FLT_EPSILON * 10.0f) {
+    if (posStoreTimer < FLT_EPSILON * 10.0f || !allowKeypointOverride) {
         return;
     }
 
     posStoreTimer = 0.0f;
     path.back() = KeyPoint(host->getTransform()->getPosition(), flightTime);
+
+    allowKeypointOverride = false;
 }
 
 void ArrowGuider::handleMouseMove(MouseMoveEvent* event)

--- a/GameProject/Game/Components/ArrowGuider.h
+++ b/GameProject/Game/Components/ArrowGuider.h
@@ -30,6 +30,7 @@ public:
     // Disables both aim and movement
     void stopGuiding(float flightTime);
 
+    // Overwrites the last keypoint with the current time and position
     void saveKeyPoint(float flightTime);
 
     // Event handlers
@@ -78,6 +79,10 @@ private:
     float posStoreTimer;
     float flightTime;
     std::vector<KeyPoint> path;
+
+    // Allow copying over the last key point in the path
+    // Used to avoid collision keypoints being written over each other
+    bool allowKeypointOverride;
 
     // The pointer is retrieved when startGuiding() is called
     Camera* arrowCamera;


### PR DESCRIPTION
If target hits happen in rapid succession, the arrow guider will end up overwriting collision keypoints, which we do not want. This fix introduces a boolean to solve this issue.