### PR TITLE
Particle system

### DIFF
--- a/GameProject/Game/Components/Explosion.cpp
+++ b/GameProject/Game/Components/Explosion.cpp
@@ -18,7 +18,7 @@ Explosion::~Explosion()
 void Explosion::update(const float & dt)
 {
 	for (auto* debri : this->debris) {
-		debri->position += debri->velocity * dt;
+		debri->position += debri->velocity * dt + 0.5f * debri->acceleration * dt * dt;
 		debri->velocity += debri->acceleration * dt;
 		debri->emitter->setPosition(debri->position);
 	}
@@ -32,27 +32,32 @@ void Explosion::update(const float & dt)
 		
 }
 
-void Explosion::explode(float lifeTime, unsigned explosionDebris, float speed, float grav)
+void Explosion::explode(float lifeTime, float timeElapsed, unsigned explosionDebris, float speed, float grav)
 {
 	this->lifeTime = lifeTime;
-	glm::vec3 entityPos = this->host->getTransform()->getPosition();
+	if (timeElapsed < this->lifeTime) {
+		glm::vec3 entityPos = this->host->getTransform()->getPosition();
 
-	srand(static_cast <unsigned> (time(0)));
-	float LO = -1.0f;
-	float HI = 1.0f;
+		srand(static_cast <unsigned> (time(0)));
+		float LO = -1.0f;
+		float HI = 1.0f;
 
-	glm::vec3 gravity(0.0f, grav, 0.0f);
+		glm::vec3 gravity(0.0f, grav, 0.0f);
 
-	for (size_t i = 0; i < explosionDebris; i++) {
-		float rx = LO + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / (HI - LO)));
-		float rz = LO + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / (HI - LO)));
-		float rSpeed = 1.0f + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / (2.0f - 1.0f)));
-		createDebri(entityPos, glm::vec3(rx, 1.0f, rz) * rSpeed, gravity, glm::vec3(0.8f), 0.15f, 0.5f);
+		for (size_t i = 0; i < explosionDebris; i++) {
+			float rx = LO + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / (HI - LO)));
+			float rz = LO + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / (HI - LO)));
+			float rSpeed = 1.0f + static_cast <float> (rand()) / (static_cast <float> (RAND_MAX / (2.0f - 1.0f)));
+			createDebri(entityPos, glm::vec3(rx, 1.0f, rz) * rSpeed, gravity, glm::vec3(0.8f), 0.15f, 0.5f);
+		}
+
+		createDebri(entityPos, glm::vec3(0.0f), glm::vec3(0.0f), glm::vec3(0.1f), 0.35f, 2.0f, 0.25f);
+
+		//If explosion is triggered with rewind the time elapsed has to be accounted for
+		this->update(timeElapsed);
+
+		this->timer = timeElapsed;
 	}
-
-	createDebri(entityPos, glm::vec3(0.0f), glm::vec3(0.0f), glm::vec3(0.1f), 0.35f, 2.0f, 0.25f);
-
-	this->timer = 0.0f;
 
 }
 

--- a/GameProject/Game/Components/Explosion.h
+++ b/GameProject/Game/Components/Explosion.h
@@ -18,7 +18,7 @@ public:
 
 	void update(const float& dt);
 
-	void explode(float lifeTime = 3.0, unsigned explosionDebris = 3, float speed = 1.5, float gravity = -3.0);
+	void explode(float lifeTime = 3.0, float timeElapsed = 0.0, unsigned explosionDebris = 3, float speed = 1.5, float gravity = -3.0);
 
 	void reset();
 

--- a/GameProject/Game/GameLogic/ReplaySystem.cpp
+++ b/GameProject/Game/GameLogic/ReplaySystem.cpp
@@ -32,8 +32,10 @@ void ReplaySystem::update(const float& dt)
 		
 		//Adds explosion on collision
 		Component * explosionComponent = collisions[collisionIndex].event.entity2->getComponent("Explosion");
-		if(explosionComponent)
-			dynamic_cast<Explosion*>(explosionComponent)->explode();
+		if (explosionComponent) {
+			float elapsedTime = replayTime - collisions[collisionIndex].time;
+			dynamic_cast<Explosion*>(explosionComponent)->explode(2.0, elapsedTime);
+		}
 
         EventBus::get().publish(&collisions[collisionIndex].event);
 


### PR DESCRIPTION
Fixed explosions in when use rewinding system, all explosions detonated at the same time. Now they should take time since collisions into consideration on their particle update.