### PR TITLE
Fix Transform::resetRoll

### DIFF
--- a/GameProject/Engine/Entity/Transform.cpp
+++ b/GameProject/Engine/Entity/Transform.cpp
@@ -85,28 +85,36 @@ glm::vec3 Transform::getUp() const
 	return this->u;
 }
 
-glm::vec3 Transform::getYawPitchRoll() const
+float Transform::getYaw() const
 {
-	glm::vec3 yawPitchRoll;
-
 	// Calculate yaw
 	glm::vec3 temp = glm::normalize(glm::vec3(this->f.x, defaultForward.y, this->f.z));
 
-	yawPitchRoll.x = glm::orientedAngle(defaultForward, temp, GLOBAL_UP_VECTOR);
+	return glm::orientedAngle(defaultForward, temp, GLOBAL_UP_VECTOR);
+}
 
+float Transform::getPitch() const
+{
 	// Calculate pitch
-	temp = glm::normalize(glm::vec3(this->f.x, 0.0f, this->f.z));
+	glm::vec3 temp = glm::normalize(glm::vec3(this->f.x, 0.0f, this->f.z));
 
-	yawPitchRoll.y = glm::orientedAngle(temp, this->f, this->r);
+	return glm::orientedAngle(temp, this->f, this->r);
+}
 
+float Transform::getRoll() const
+{
 	// Calculate roll
-	glm::vec3 horizontalRight = glm::normalize(glm::cross(this->f, GLOBAL_UP_VECTOR));
-	temp = glm::normalize(glm::cross(horizontalRight, this->f));
+	// Horizontal right vec
+	glm::vec3 temp = glm::normalize(glm::cross(this->f, GLOBAL_UP_VECTOR));
+	// Up vector without roll
+	temp = glm::normalize(glm::cross(temp, this->f));
 
-	// Determine roll sign
-	yawPitchRoll.z = glm::orientedAngle(temp, this->u, this->f);
+	return glm::orientedAngle(temp, this->u, this->f);
+}
 
-	return yawPitchRoll;
+glm::vec3 Transform::getYawPitchRoll() const
+{
+	return {this->getYaw(), this->getPitch(), this->getRoll()};
 }
 
 glm::vec3 Transform::getDefaultForward() const
@@ -281,6 +289,14 @@ void Transform::rotate(const float yaw, const float pitch, const float roll)
 
 void Transform::resetRoll()
 {
-	this->r = glm::normalize(glm::vec3(r.x, 0.0f, r.z));
-	this->u = glm::cross(this->r, this->f);
+	float roll = getRoll();
+
+	glm::quat rollQuat = glm::angleAxis(roll, this->f);
+
+	this->r = glm::normalize(rollQuat * this->r);
+	this->u = glm::normalize(rollQuat * this->u);
+
+	rotationQuat = rollQuat * rotationQuat;
+
+	this->isUpdated = true;
 }

--- a/GameProject/Engine/Entity/Transform.h
+++ b/GameProject/Engine/Entity/Transform.h
@@ -45,6 +45,10 @@ public:
 	//Get up vector
 	glm::vec3 getUp() const;
 
+	float getYaw() const;
+	float getPitch() const;
+	float getRoll() const;
+
 	glm::vec3 getYawPitchRoll() const;
 
 	glm::vec3 getDefaultForward() const;

--- a/GameProject/Game/Components/RollNullifier.cpp
+++ b/GameProject/Game/Components/RollNullifier.cpp
@@ -13,20 +13,8 @@ void RollNullifier::update(const float& dt)
 {
     // Calculate roll
 	Transform* transform = host->getTransform();
-    glm::vec3 rightVec = transform->getRight();
 
-	// Do not proceed if there is no roll
-	if (std::abs(rightVec.y) < FLT_EPSILON) {
-		return;
-	}
-
-    glm::vec3 horizontalRight = glm::normalize(glm::vec3(rightVec.x, 0.0f, rightVec.z));
-
-	float cosRoll = glm::min<float>(glm::dot(rightVec, horizontalRight), 1.0f - FLT_EPSILON);
-
-    float roll = std::acosf(cosRoll);
-
-    roll = (rightVec.y > 0.0f) ? -roll : roll;
+    float roll = transform->getRoll();
 
     // Calculate roll delta
 	float rollDelta = roll * (rollNullifyFactor - 1.0f) * dt;


### PR DESCRIPTION
`Transform::resetRoll` wasn't updating the transform's rotation quaternion. This lead to multiple problems, among them being that the roll nullifier wouldn't do anything.

Also took the opportunity to write individual get functions in `Transform` for yaw, pitch and roll.