### PR TITLE
Score menu displayable before ending replay

### DIFF
--- a/GameProject/Game/GameLogic/Phases/ReplayPhase.h
+++ b/GameProject/Game/GameLogic/Phases/ReplayPhase.h
@@ -33,8 +33,6 @@ private:
 
     void handleTimeBarClick();
 
-    void createScoreMenu();
-
     Entity* freeCam;
     FreeMove* freeMove;
 

--- a/GameProject/Game/GameLogic/Phases/ReplayPhase.h
+++ b/GameProject/Game/GameLogic/Phases/ReplayPhase.h
@@ -33,6 +33,8 @@ private:
 
     void handleTimeBarClick();
 
+    void createScoreMenu();
+
     Entity* freeCam;
     FreeMove* freeMove;
 
@@ -67,7 +69,7 @@ private:
     // Time bar slider (purely cosmetic)
     Panel* timeBarSlider;
 
-	bool guiExist;
+	bool timebarExists;
 
     // Size relative to screen height
     const glm::vec2 sliderSizeFactors = {timeBarHeightFactor, timeBarHeightFactor};


### PR DESCRIPTION
During replay:
- The score menu is created in its minimized format immediately
- Escape will toggle the minimized/enlarged format (previously this was only possible after finishing the replay)