### PR TITLE
Collision free transitions

### DIFF
--- a/GameProject/Game/Components/CameraTransition.cpp
+++ b/GameProject/Game/Components/CameraTransition.cpp
@@ -25,19 +25,37 @@ CameraTransition::~CameraTransition()
 
 void CameraTransition::setDestination(const glm::vec3& newPos, const glm::vec3& newForward, float newFOV, float transitionLength)
 {
+    std::queue<KeyPoint> newPath;
+
+    newPath.push(KeyPoint(newPos, transitionLength));
+
+    this->setPath(newPath, newForward, newFOV);
+}
+
+void CameraTransition::setPath(const std::queue<KeyPoint>& path, const glm::vec3& newForward, float newFOV)
+{
+    if (path.empty()) {
+        LOG_WARNING("Transition path is empty!");
+
+        this->isTransitioning = false;
+        return;
+    }
+
     this->isTransitioning = true;
     this->transitionTime = 0.0f;
-    this->transitionLength = transitionLength;
-    this->endPos = newPos;
+    this->beginT = 0.0f;
+    this->path = path;
 
+    // Calculate final rotation quaternion
     Transform* transform = host->getTransform();
 
-    this->beginPos = transform->getPosition();
     this->defaultForward = transform->getDefaultForward();
 
-    // Apply yaw and pitch to the current rotation quat to calculate the end quat
     this->beginQuat = transform->getRotationQuat();
 
+    this->beginPos = transform->getPosition();
+
+    // Quaternion for achieving the forward direction for the next point in the path
 	this->endQuat = glm::rotation(transform->getDefaultForward(), newForward);
 
     // Attempt to get entity camera to read and write FOV
@@ -48,8 +66,9 @@ void CameraTransition::setDestination(const glm::vec3& newPos, const glm::vec3& 
         return;
     }
 
-    beginFOV = entityCam->getFOV();
-    endFOV = newFOV;
+    // Starting FOV and the final FOV for the transition
+    this->beginFOV = entityCam->getFOV();
+    this->endFOV = newFOV;
 }
 
 void CameraTransition::update(const float& dt)
@@ -58,29 +77,43 @@ void CameraTransition::update(const float& dt)
         return;
     }
 
+    Transform* transform = host->getTransform();
+
     transitionTime += dt;
 
-    if (transitionTime > transitionLength) {
-        isTransitioning = false;
+    while (transitionTime > path.front().t) {
+        // The next point in the path has been reached
+        path.pop();
 
-        // Publish camera transition event
-        EventBus::get().publish(&CameraTransitionEvent(host));
+        if (path.size() > 0) {
+            this->beginPos = transform->getPosition();
+            this->beginT = transitionTime;
+        }
 
-		return;
+        else {
+            // Transition is finished
+            isTransitioning = false;
+
+            // Publish camera transition event
+            EventBus::get().publish(&CameraTransitionEvent(host));
+
+            return;
+        }
     }
 
     // Get the slerp factor T in [0,1]
-    float T = transitionTime / transitionLength;
+    float T = transitionTime / path.back().t;
 
     // Calculate current rotation quat
     glm::quat currentRotationQuat = glm::slerp(beginQuat, endQuat, T);
 
     // Calculate current position
-    glm::vec3 currentPosition = glm::mix(beginPos, endPos, T);
+    // The position interpolation needs a different T than the rotation
+    T = (transitionTime - beginT) / (path.front().t - beginT);
+
+    glm::vec3 currentPosition = glm::mix(beginPos, path.front().Position, T);
 
     // Set new rotation and position
-    Transform* transform = host->getTransform();
-
     transform->setForward(currentRotationQuat * host->getTransform()->getDefaultForward());
 	transform->setPosition(currentPosition);
 

--- a/GameProject/Game/Components/CameraTransition.h
+++ b/GameProject/Game/Components/CameraTransition.h
@@ -4,7 +4,7 @@
 #include <Game/Components/ComponentResources.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
-#include <queue>
+#include <vector>
 
 class Camera;
 
@@ -16,15 +16,12 @@ public:
     ~CameraTransition();
 
     void setDestination(const glm::vec3& newPos, const glm::vec3& newForward, float newFOV, float transitionLength);
-    void setPath(const std::queue<KeyPoint>& path, const glm::vec3& newForward, float newFOV);
+    void setPath(const std::vector<KeyPoint>& path, const glm::vec3& newForward, float newFOV);
 
     void update(const float& dt);
 private:
     // Quaternions for the default forward and final forward directions
     glm::quat beginQuat, endQuat;
-
-    // Position at the beginning of the current point in the path
-    glm::vec3 beginPos;
 
     glm::vec3 defaultForward;
 
@@ -39,5 +36,7 @@ private:
 
     bool isTransitioning;
 
-    std::queue<KeyPoint> path;
+    std::vector<KeyPoint> path;
+
+    unsigned int pathIndex;
 };

--- a/GameProject/Game/Components/CameraTransition.h
+++ b/GameProject/Game/Components/CameraTransition.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <Engine/Components/Component.h>
+#include <Game/Components/ComponentResources.h>
 #include <glm/glm.hpp>
 #include <glm/gtc/quaternion.hpp>
+#include <queue>
 
 class Camera;
 
@@ -14,20 +16,28 @@ public:
     ~CameraTransition();
 
     void setDestination(const glm::vec3& newPos, const glm::vec3& newForward, float newFOV, float transitionLength);
+    void setPath(const std::queue<KeyPoint>& path, const glm::vec3& newForward, float newFOV);
 
     void update(const float& dt);
 private:
-    // Beginning and end quaternions for the rotation
+    // Quaternions for the default forward and final forward directions
     glm::quat beginQuat, endQuat;
 
-    glm::vec3 beginPos, endPos;
+    // Position at the beginning of the current point in the path
+    glm::vec3 beginPos;
+
     glm::vec3 defaultForward;
 
     float beginFOV, endFOV;
 
     Camera* entityCam;
 
-    float transitionTime, transitionLength;
+    float transitionTime;
+
+    // Timestamp at previous path point
+    float beginT;
 
     bool isTransitioning;
+
+    std::queue<KeyPoint> path;
 };

--- a/GameProject/Game/Components/CameraTransition.h
+++ b/GameProject/Game/Components/CameraTransition.h
@@ -20,6 +20,8 @@ public:
 
     void update(const float& dt);
 private:
+    void catmullRomMove();
+
     // Quaternions for the default forward and final forward directions
     glm::quat beginQuat, endQuat;
 

--- a/GameProject/Game/Components/PathTreader.cpp
+++ b/GameProject/Game/Components/PathTreader.cpp
@@ -1,8 +1,9 @@
 #include "PathTreader.h"
 
 #include <Engine/Entity/Entity.h>
-#include "Utils/Logger.h"
-#include "Utils/Utils.h"
+#include <Utils/Logger.h>
+#include <Utils/Utils.h>
+#include <glm/gtx/spline.hpp>
 
 PathTreader::PathTreader(Entity* host)
     :Component(host, "PathTreader")

--- a/GameProject/Game/Components/PathTreader.h
+++ b/GameProject/Game/Components/PathTreader.h
@@ -3,7 +3,6 @@
 #include <Engine/Components/Component.h>
 #include <Engine/Entity/Transform.h>
 #include <Game/components/ComponentResources.h>
-#include <glm/gtx/spline.hpp>
 #include <vector>
 
 class Entity;

--- a/GameProject/Game/GameLogic/Phases/AimPhase.cpp
+++ b/GameProject/Game/GameLogic/Phases/AimPhase.cpp
@@ -177,7 +177,7 @@ void AimPhase::handleKeyInput(KeyEvent* event)
 
         CameraSetting newCamSettings = level.player.oversightCamera;
 
-        this->setupTransition(currentCamSettings, newCamSettings);
+        this->transitionAboveWalls(currentCamSettings, newCamSettings);
 
         EventBus::get().subscribe(this, &AimPhase::transitionToOverview);
     }

--- a/GameProject/Game/GameLogic/Phases/GuidingPhase.cpp
+++ b/GameProject/Game/GameLogic/Phases/GuidingPhase.cpp
@@ -108,7 +108,7 @@ void GuidingPhase::beginReplayTransition()
 
     CameraSetting newCamSettings = level.player.replayCamera;
 
-    this->setupTransition(currentCamSettings, newCamSettings);
+    this->transitionStraightPath(currentCamSettings, newCamSettings);
 
     EventBus::get().subscribe(this, &GuidingPhase::finishReplayTransition);
 }

--- a/GameProject/Game/GameLogic/Phases/OverviewPhase.cpp
+++ b/GameProject/Game/GameLogic/Phases/OverviewPhase.cpp
@@ -115,7 +115,7 @@ void OverviewPhase::handleKeyInput(KeyEvent* event)
 
         newCamSettings.direction = playerArrow->getTransform()->getForward();
 
-        this->setupTransition(currentCamSettings, newCamSettings);
+        this->transitionAboveWalls(currentCamSettings, newCamSettings);
 
         EventBus::get().subscribe(this, &OverviewPhase::transitionToAim);
     }

--- a/GameProject/Game/GameLogic/Phases/Phase.cpp
+++ b/GameProject/Game/GameLogic/Phases/Phase.cpp
@@ -4,6 +4,7 @@
 #include <Engine/Rendering/Display.h>
 #include <Engine/Rendering/Renderer.h>
 #include <Engine/Entity/Entity.h>
+#include <queue>
 
 Phase::Phase(const Level& level, Entity* transitionEntity)
     :level(level),
@@ -34,23 +35,13 @@ void Phase::changePhase(Phase* newPhase)
     EventBus::get().publish(&PhaseChangeEvent(newPhase));
 }
 
-void Phase::setupTransition(const CameraSetting& currentCamSettings, const CameraSetting& newCamSettings)
+void Phase::transitionStraightPath(const CameraSetting& currentCamSettings, const CameraSetting& newCamSettings)
 {
     // Calculate current camera position
-    glm::vec3 currentRight = glm::normalize(glm::cross(currentCamSettings.direction, GLOBAL_UP_VECTOR));
-
-    glm::vec3 currentOffset = currentCamSettings.direction * currentCamSettings.offset.z +
-    currentRight * currentCamSettings.offset.x + GLOBAL_UP_VECTOR * currentCamSettings.offset.y;
-
-    glm::vec3 currentPos = currentCamSettings.position + currentOffset;
+    glm::vec3 currentPos = this->calculatePosition(currentCamSettings);
 
     // Calculate new camera position
-    glm::vec3 newRight = glm::normalize(glm::cross(newCamSettings.direction, GLOBAL_UP_VECTOR));
-
-    glm::vec3 destinationOffset = newCamSettings.direction * newCamSettings.offset.z +
-    newRight * newCamSettings.offset.x + GLOBAL_UP_VECTOR * newCamSettings.offset.y;
-
-    glm::vec3 newPos = newCamSettings.position + destinationOffset;
+    glm::vec3 newPos = this->calculatePosition(newCamSettings);
 
     float transitionLength = 2.0f;
 
@@ -66,4 +57,71 @@ void Phase::setupTransition(const CameraSetting& currentCamSettings, const Camer
     transitionComponent->setDestination(newPos, newCamSettings.direction, newCamSettings.FOV, transitionLength);
 
     Display::get().getRenderer().setActiveCamera(transitionCam);
+}
+
+void Phase::transitionAboveWalls(const CameraSetting& currentCamSettings, const CameraSetting& newCamSettings)
+{
+    float wallHeight = level.levelStructure->getWallHeight();
+    float heightMarginFactor = 2.0f;
+    float transitionLength = 2.5f;
+
+    // Get the current camera position, account for offset
+    glm::vec3 currentPos = this->calculatePosition(currentCamSettings);
+
+    // Height to position far-up points at
+    float pathHeight  = wallHeight * 1.2f;
+
+    pathHeight = (currentPos.y > wallHeight * heightMarginFactor) ? currentPos.y : wallHeight * heightMarginFactor;
+
+    std::queue<KeyPoint> transitionPath;
+
+    KeyPoint point;
+
+    // P0: directly above camera, only added if camera is below ceiling
+    if (currentPos.y < wallHeight * heightMarginFactor) {
+        point.Position = {currentPos.x, pathHeight * 1.2f, currentPos.z};
+        point.t = transitionLength / 3.0f;
+
+        transitionPath.push(point);
+    }
+
+    glm::vec3 destinationPos = this->calculatePosition(newCamSettings);
+
+    // P1: directly above destination, only added if the camera is currently above the ceiling
+    if (currentPos.y > wallHeight * heightMarginFactor) {
+        point.Position = {destinationPos.x, pathHeight * 1.2f, destinationPos.z};    
+        point.t = transitionLength * 2.0f / 3.0f;
+
+        transitionPath.push(point);
+    }
+
+    // P2: destination
+    point.Position = destinationPos;
+    point.t = transitionLength;
+
+    transitionPath.push(point);
+
+    // Set current camera settins to the transition camera
+    transitionEntity->getTransform()->setPosition(currentPos);
+    transitionEntity->getTransform()->setForward(currentCamSettings.direction);
+
+    transitionCam->setFOV(currentCamSettings.FOV);
+    transitionCam->setOffset(glm::vec3(0.0f, 0.0f, 0.0f));
+
+    // Update view matrix with new transform settings
+    transitionCam->update(0.0f);
+
+    transitionComponent->setPath(transitionPath, newCamSettings.direction, newCamSettings.FOV);
+
+    Display::get().getRenderer().setActiveCamera(transitionCam);
+}
+
+glm::vec3 Phase::calculatePosition(const CameraSetting& camSettings)
+{
+    glm::vec3 horizontalRight = glm::normalize(glm::cross(camSettings.direction, GLOBAL_UP_VECTOR));
+
+    glm::vec3 realOffset = camSettings.direction * camSettings.offset.z +
+    horizontalRight * camSettings.offset.x + GLOBAL_UP_VECTOR * camSettings.offset.y;
+
+    return camSettings.position + realOffset;
 }

--- a/GameProject/Game/GameLogic/Phases/Phase.cpp
+++ b/GameProject/Game/GameLogic/Phases/Phase.cpp
@@ -78,7 +78,7 @@ void Phase::transitionAboveWalls(const CameraSetting& currentCamSettings, const 
 
     KeyPoint point;
 
-    // P0: directly above the current camera, only added if the camera is currently below the ceiling
+    // P0: directly above the current camera, only added if the current camera is below the ceiling
     if (currentPos.y < wallHeight * heightMarginFactor) {
         point.Position = {currentPos.x, pathHeight * 1.2f, currentPos.z};
         point.t = transitionLength / 3.0f;
@@ -86,8 +86,8 @@ void Phase::transitionAboveWalls(const CameraSetting& currentCamSettings, const 
         transitionPath.push(point);
     }
 
-    // P0: directly above destination, only added if the camera is currently above the ceiling
-    else if (currentPos.y > wallHeight * heightMarginFactor) {
+    // P0/P1: directly above destination, only added if the target camera is below the ceiling
+    if (destinationPos.y < wallHeight * heightMarginFactor) {
         point.Position = {destinationPos.x, pathHeight * 1.2f, destinationPos.z};    
         point.t = transitionLength * 2.0f / 3.0f;
 

--- a/GameProject/Game/GameLogic/Phases/Phase.cpp
+++ b/GameProject/Game/GameLogic/Phases/Phase.cpp
@@ -65,8 +65,9 @@ void Phase::transitionAboveWalls(const CameraSetting& currentCamSettings, const 
     float heightMarginFactor = 2.0f;
     float transitionLength = 2.5f;
 
-    // Get the current camera position, account for offset
+    // Get the starting and destinnation camera positions by accounting for offset
     glm::vec3 currentPos = this->calculatePosition(currentCamSettings);
+    glm::vec3 destinationPos = this->calculatePosition(newCamSettings);
 
     // Height to position far-up points at
     float pathHeight  = wallHeight * 1.2f;
@@ -77,7 +78,7 @@ void Phase::transitionAboveWalls(const CameraSetting& currentCamSettings, const 
 
     KeyPoint point;
 
-    // P0: directly above camera, only added if camera is below ceiling
+    // P0: directly above the current camera, only added if the camera is currently below the ceiling
     if (currentPos.y < wallHeight * heightMarginFactor) {
         point.Position = {currentPos.x, pathHeight * 1.2f, currentPos.z};
         point.t = transitionLength / 3.0f;
@@ -85,17 +86,15 @@ void Phase::transitionAboveWalls(const CameraSetting& currentCamSettings, const 
         transitionPath.push(point);
     }
 
-    glm::vec3 destinationPos = this->calculatePosition(newCamSettings);
-
-    // P1: directly above destination, only added if the camera is currently above the ceiling
-    if (currentPos.y > wallHeight * heightMarginFactor) {
+    // P0: directly above destination, only added if the camera is currently above the ceiling
+    else if (currentPos.y > wallHeight * heightMarginFactor) {
         point.Position = {destinationPos.x, pathHeight * 1.2f, destinationPos.z};    
         point.t = transitionLength * 2.0f / 3.0f;
 
         transitionPath.push(point);
     }
 
-    // P2: destination
+    // P1: destination
     point.Position = destinationPos;
     point.t = transitionLength;
 

--- a/GameProject/Game/GameLogic/Phases/Phase.h
+++ b/GameProject/Game/GameLogic/Phases/Phase.h
@@ -19,7 +19,10 @@ public:
 protected:
     void changePhase(Phase* newPhase);
 
-    void setupTransition(const CameraSetting& currentCamSettings, const CameraSetting& newCamSettings);
+    // Begins camera transition in a straight path
+    void transitionStraightPath(const CameraSetting& currentCamSettings, const CameraSetting& newCamSettings);
+    // Transitions above walls
+    void transitionAboveWalls(const CameraSetting& currentCamSettings, const CameraSetting& newCamSettings);
 
     Level level;
 
@@ -27,4 +30,8 @@ protected:
     Entity* transitionEntity;
     Camera* transitionCam;
     CameraTransition* transitionComponent;
+
+private:
+    // Calculate the position of a camera by accounting for offset
+    glm::vec3 calculatePosition(const CameraSetting& camSettings);
 };

--- a/GameProject/Game/GameLogic/Phases/ReplayPhase.cpp
+++ b/GameProject/Game/GameLogic/Phases/ReplayPhase.cpp
@@ -191,7 +191,7 @@ void ReplayPhase::beginAimTransition()
 
     CameraSetting newCamSettings = level.player.arrowCamera;
 
-    this->setupTransition(currentCamSettings, newCamSettings);
+    this->transitionStraightPath(currentCamSettings, newCamSettings);
 
     EventBus::get().subscribe(this, &ReplayPhase::finishAimTransition);
 }

--- a/GameProject/Game/Level/LevelStructure.cpp
+++ b/GameProject/Game/Level/LevelStructure.cpp
@@ -101,11 +101,16 @@ std::vector<glm::vec3>& LevelStructure::getWallPoints()
 {
 	return this->wallPoints;
 }
+
 std::vector<int>& LevelStructure::getWallGroupsIndex()
 {
 	return this->wallGroupsIndex;
 }
 
+float LevelStructure::getWallHeight() const
+{
+	return this->height;
+}
 
 Model * LevelStructure::createQuad()
 {

--- a/GameProject/Game/Level/LevelStructure.h
+++ b/GameProject/Game/Level/LevelStructure.h
@@ -23,6 +23,8 @@ public:
 	// Get all wall groups index
 	std::vector<int>& getWallGroupsIndex();
 
+	float getWallHeight() const;
+
 private:
 	// Create quad model for walls
 	Model* createQuad();


### PR DESCRIPTION
The camera transition component is now able to accept a path rather than a single point to transition towards. This is used to send the camera above the walls before moving horizontally when transitioning between the Aim phase and Guiding phase.

The transition isn't particularly satisfying at the moment as the camera transitions linearly between point, meaning sharp turns occur when the camera hits a point in the path. I am considering implementing Catmull-Rom for the camera transitions, but will do so at a later point once more important tasks have been completed.

Collision-free transitions from Guiding to Replay will be done in a separate branch.