### PR TITLE
Fix level exiting

### DIFF
--- a/GameProject/Game/States/GameState.cpp
+++ b/GameProject/Game/States/GameState.cpp
@@ -43,6 +43,7 @@ GameState::GameState(const std::string& levelJSON)
 	InputHandler ih(Display::get().getWindowPtr());
 
 	EventBus::get().subscribe(this, &GameState::exitGame);
+	this->hasSubscribedToExit = true;
 
 	//For pause event
 	this->hasSubscribedToPause = false;
@@ -67,6 +68,12 @@ void GameState::start()
 	std::vector<Entity*>& entities = entityManager.getAll();
 	for (Entity* entity : entities)
 		entity->attachToModel();
+
+	if (!hasSubscribedToExit) {
+		EventBus::get().subscribe(this, &GameState::exitGame);
+
+		this->hasSubscribedToExit = true;
+	}
 }
 
 void GameState::end()
@@ -81,6 +88,8 @@ void GameState::end()
 
 	EventBus::get().unsubscribe(this, &GameState::pauseGame);
 	EventBus::get().unsubscribe(this, &GameState::exitGame);
+
+	this->hasSubscribedToExit = false;
 	this->hasSubscribedToPause = false;
 }
 

--- a/GameProject/Game/States/GameState.h
+++ b/GameProject/Game/States/GameState.h
@@ -25,7 +25,7 @@ private:
 	void pauseGame(PauseEvent * ev);
 	void exitGame(ExitEvent* ev);
 
-	bool hasSubscribedToPause;
+	bool hasSubscribedToPause, hasSubscribedToExit;
 
 	LevelParser levelParser;
 	TargetManager* targetManager;


### PR DESCRIPTION
When `GameState` is deleted, it unsubscribes from `ExitEvent`. When it is started again, it did not subscribe to the event again and so exiting through the `Score` menu was not possible.